### PR TITLE
Add unit tests for UI component primitives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Vitest / Jest coverage output
+coverage/

--- a/src/components/ui/__tests__/badges.test.tsx
+++ b/src/components/ui/__tests__/badges.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { OutlineBadge, SecondaryBadge } from "../badges";
+
+describe("SecondaryBadge", () => {
+  it("renders the badge with its slot, default classes, and merged className", () => {
+    render(<SecondaryBadge tagName="TypeScript" className="custom-secondary" />);
+
+    const badge = screen.getByText("TypeScript");
+    expect(badge).toHaveAttribute("data-slot", "badge");
+    expect(badge).toHaveClass("inline-flex", "border-transparent", "bg-secondary");
+    expect(badge).toHaveClass("custom-secondary");
+  });
+});
+
+describe("OutlineBadge", () => {
+  it("applies the outline styling and keeps additional classes", () => {
+    render(<OutlineBadge tagName="React" className="custom-outline" />);
+
+    const badge = screen.getByText("React");
+    expect(badge).toHaveAttribute("data-slot", "badge");
+    expect(badge).toHaveClass("inline-flex", "text-foreground");
+    expect(badge).toHaveClass("custom-outline");
+  });
+});

--- a/src/components/ui/__tests__/buttons.test.tsx
+++ b/src/components/ui/__tests__/buttons.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { HeaderButton, ProjectButton, ThemeButton } from "../buttons";
+
+describe("HeaderButton", () => {
+  it("renders a header button with hover underline span and click handler", () => {
+    const handleClick = vi.fn();
+    render(
+      <HeaderButton
+        buttonName="Docs"
+        onClick={handleClick}
+        className="custom-underline"
+      />
+    );
+
+    const button = screen.getByRole("button", { name: "Docs" });
+    expect(button).toHaveAttribute("data-slot", "header-button");
+    expect(button).toHaveClass("group");
+
+    fireEvent.click(button);
+    expect(handleClick).toHaveBeenCalled();
+
+    const underline = button.querySelector("span");
+    expect(underline).not.toBeNull();
+    expect(underline).toHaveClass("absolute", "-bottom-1", "custom-underline");
+  });
+});
+
+describe("ProjectButton", () => {
+  it("renders as a standard button with ghost small variant classes", () => {
+    render(
+      <ProjectButton className="project-custom">Launch Project</ProjectButton>
+    );
+
+    const button = screen.getByRole("button", { name: "Launch Project" });
+    expect(button).toHaveAttribute("data-slot", "project-button");
+    expect(button).toHaveClass("hover:bg-accent", "h-8", "project-custom");
+  });
+
+  it("can render as a child component while preserving its styling", () => {
+    render(
+      <ProjectButton asChild className="link-custom">
+        <a href="#docs">View Docs</a>
+      </ProjectButton>
+    );
+
+    const link = screen.getByRole("link", { name: "View Docs" });
+    expect(link.tagName).toBe("A");
+    expect(link).toHaveAttribute("data-slot", "project-button");
+    expect(link).toHaveClass("hover:bg-accent", "h-8", "link-custom");
+  });
+});
+
+describe("ThemeButton", () => {
+  it("renders a ghost icon button and fires click events", () => {
+    const handleClick = vi.fn();
+    render(
+      <ThemeButton
+        aria-label="Toggle theme"
+        onClick={handleClick}
+        className="theme-custom"
+      />
+    );
+
+    const button = screen.getByRole("button", { name: "Toggle theme" });
+    expect(button).toHaveAttribute("data-slot", "theme-button");
+    expect(button).toHaveClass("hover:bg-accent", "size-9", "theme-custom");
+
+    fireEvent.click(button);
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it("supports asChild usage and forwards interactions", () => {
+    const handleClick = vi.fn();
+    render(
+      <ThemeButton
+        asChild
+        className="link-theme"
+        onClick={handleClick}
+      >
+        <a href="#theme" aria-label="Theme link" />
+      </ThemeButton>
+    );
+
+    const link = screen.getByLabelText("Theme link");
+    expect(link.tagName).toBe("A");
+    expect(link).toHaveAttribute("data-slot", "theme-button");
+    expect(link).toHaveClass("hover:bg-accent", "size-9", "link-theme");
+
+    fireEvent.click(link);
+    expect(handleClick).toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/__tests__/cards.test.tsx
+++ b/src/components/ui/__tests__/cards.test.tsx
@@ -1,0 +1,98 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { ComponentType } from "react";
+
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "../cards";
+
+type Case = {
+  name: string;
+  Component: ComponentType<any>;
+  slot: string;
+  tagName: string;
+  expectedClasses: string[];
+};
+
+const cases: Case[] = [
+  {
+    name: "Card",
+    Component: Card,
+    slot: "card",
+    tagName: "DIV",
+    expectedClasses: ["bg-card", "rounded-xl"],
+  },
+  {
+    name: "CardHeader",
+    Component: CardHeader,
+    slot: "card-header",
+    tagName: "DIV",
+    expectedClasses: ["grid", "px-6"],
+  },
+  {
+    name: "CardTitle",
+    Component: CardTitle,
+    slot: "card-title",
+    tagName: "H4",
+    expectedClasses: ["leading-none"],
+  },
+  {
+    name: "CardDescription",
+    Component: CardDescription,
+    slot: "card-description",
+    tagName: "P",
+    expectedClasses: ["text-muted-foreground"],
+  },
+  {
+    name: "CardAction",
+    Component: CardAction,
+    slot: "card-action",
+    tagName: "DIV",
+    expectedClasses: ["justify-self-end"],
+  },
+  {
+    name: "CardContent",
+    Component: CardContent,
+    slot: "card-content",
+    tagName: "DIV",
+    expectedClasses: ["px-6"],
+  },
+  {
+    name: "CardFooter",
+    Component: CardFooter,
+    slot: "card-footer",
+    tagName: "DIV",
+    expectedClasses: ["flex", "px-6"],
+  },
+];
+
+describe("Card primitives", () => {
+  cases.forEach(({ name, Component, slot, tagName, expectedClasses }) => {
+    it(`renders ${name} with its slot, base classes, and forwarded props`, () => {
+      const { getByTestId } = render(
+        <Component
+          data-testid="primitive"
+          className="custom-class"
+          aria-label="card-primitive"
+        >
+          Content
+        </Component>
+      );
+
+      const element = getByTestId("primitive");
+      expect(element.tagName).toBe(tagName);
+      expect(element).toHaveAttribute("data-slot", slot);
+      expectedClasses.forEach((className) => {
+        expect(element).toHaveClass(className);
+      });
+      expect(element).toHaveClass("custom-class");
+      expect(element).toHaveAttribute("aria-label", "card-primitive");
+    });
+  });
+});

--- a/src/components/ui/__tests__/cards.test.tsx
+++ b/src/components/ui/__tests__/cards.test.tsx
@@ -14,7 +14,15 @@ import {
 
 type Case = {
   name: string;
-  Component: ComponentType<any>;
+  Component: ComponentType<
+    | Card
+    | CardHeader
+    | CardTitle
+    | CardDescription
+    | CardAction
+    | CardContent
+    | CardFooter
+  >;
   slot: string;
   tagName: string;
   expectedClasses: string[];
@@ -82,7 +90,7 @@ describe("Card primitives", () => {
           aria-label="card-primitive"
         >
           Content
-        </Component>
+        </Component>,
       );
 
       const element = getByTestId("primitive");

--- a/src/components/ui/__tests__/dom.test.ts
+++ b/src/components/ui/__tests__/dom.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { scrollToSection } from "../dom";
+
+describe("scrollToSection", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("calls scrollIntoView on the matching element with smooth behavior", () => {
+    const section = document.createElement("div");
+    section.id = "overview";
+    const scrollSpy = vi.fn();
+    section.scrollIntoView = scrollSpy;
+    document.body.append(section);
+
+    scrollToSection("#overview");
+
+    expect(scrollSpy).toHaveBeenCalledWith({ behavior: "smooth" });
+  });
+
+  it("does nothing when the selector does not match an element", () => {
+    expect(() => scrollToSection("#missing")).not.toThrow();
+  });
+});

--- a/src/components/ui/__tests__/utils.test.ts
+++ b/src/components/ui/__tests__/utils.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { cn } from "../utils";
+
+describe("cn", () => {
+  it("combines truthy class names and flattens arrays", () => {
+    expect(
+      cn("text-sm", null, ["font-semibold", ["tracking-tight"]], {
+        hidden: false,
+        block: true,
+      })
+    ).toBe("text-sm font-semibold tracking-tight block");
+  });
+
+  it("merges tailwind classes using tailwind-merge", () => {
+    expect(cn("px-2", "px-4", "px-4")).toBe("px-4");
+  });
+});


### PR DESCRIPTION
## Summary
- add badge tests to confirm rendered slots, styling, and custom class merging
- cover button variants for click handlers, `asChild` usage, and ghost/icon styling
- exercise card subcomponents, DOM scroll helper, and `cn` utility for class forwarding

## Testing
- yarn test *(fails: dependencies cannot be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_690087f793a8832cae9931e22b0d23f6