### PR TITLE
Add tests for Certificate component

### DIFF
--- a/src/components/__tests__/Certificate.test.tsx
+++ b/src/components/__tests__/Certificate.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 
 import Certificate from "../Certificate";
 import { certificates } from "@avalon/configs/galahad";
@@ -21,14 +21,23 @@ describe("Certificate", () => {
     render(<Certificate isDark={false} />);
 
     certificates.forEach((cert) => {
-      expect(screen.getByText(cert.name)).toBeInTheDocument();
-      expect(screen.getByText(cert.issuer)).toBeInTheDocument();
-      expect(screen.getByText(cert.credentialId)).toBeInTheDocument();
-    });
+      const card = screen
+        .getByText(cert.name)
+        .closest('[data-slot="card"]') as HTMLElement | null;
 
-    expect(screen.getAllByText(/credential id/i)).toHaveLength(
-      certificates.length
-    );
+      expect(card).not.toBeNull();
+
+      if (!card) {
+        throw new Error(`Certificate card not found for ${cert.name}`);
+      }
+
+      const cardWithin = within(card);
+
+      expect(cardWithin.getByText(cert.name)).toBeInTheDocument();
+      expect(cardWithin.getByText(cert.issuer)).toBeInTheDocument();
+      expect(cardWithin.getByText(/credential id/i)).toBeInTheDocument();
+      expect(cardWithin.getByText(cert.credentialId)).toBeInTheDocument();
+    });
   });
 
   it("uses the appropriate certificate badge variant depending on the theme", () => {

--- a/src/components/__tests__/Certificate.test.tsx
+++ b/src/components/__tests__/Certificate.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+
+import Certificate from "../Certificate";
+import { certificates } from "@avalon/configs/galahad";
+
+describe("Certificate", () => {
+  it("renders the section header and description", () => {
+    render(<Certificate isDark={false} />);
+
+    expect(
+      screen.getByRole("heading", { name: /certificates & credentials/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /professional certifications and credentials that validate my expertise across various technologies and platforms\./i
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("displays a card for each certificate with its details", () => {
+    render(<Certificate isDark={false} />);
+
+    certificates.forEach((cert) => {
+      expect(screen.getByText(cert.name)).toBeInTheDocument();
+      expect(screen.getByText(cert.issuer)).toBeInTheDocument();
+      expect(screen.getByText(cert.credentialId)).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText(/credential id/i)).toHaveLength(
+      certificates.length
+    );
+  });
+
+  it("uses the appropriate certificate badge variant depending on the theme", () => {
+    const { rerender } = render(<Certificate isDark={false} />);
+
+    certificates.forEach((cert) => {
+      expect(screen.getByAltText(`${cert.name} Badge`)).toHaveAttribute(
+        "src",
+        cert.logoSrc
+      );
+    });
+
+    rerender(<Certificate isDark />);
+
+    certificates.forEach((cert) => {
+      expect(screen.getByAltText(`${cert.name} Badge`)).toHaveAttribute(
+        "src",
+        cert.logoSrcDark
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for the Certificate section header and description
- cover certificate cards to ensure details render from configuration
- verify the correct badge variant is used for light and dark themes

## Testing
- yarn test *(fails: yarn install blocked by registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_690098c400b0832c80e80dad6746d983