### PR TITLE
Configure Vitest coverage reporter for badge generation

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,5 +17,10 @@ export default defineConfig({
     setupFiles: "./src/setupTests.ts",
     include: ["src/**/*.{test,spec}.{ts,tsx}"],
     css: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json-summary"],
+      reportsDirectory: "./coverage",
+    },
   },
 });


### PR DESCRIPTION
## Summary
- configure Vitest coverage to use the v8 provider
- emit text and json-summary reports into the coverage directory for badge generation

## Testing
- Not run (dependency installation failed in the environment)

------
https://chatgpt.com/codex/tasks/task_e_69047e4607a0832ca48004b8f7cc3226