### PR TITLE
Add unit tests for footer and experience components

### DIFF
--- a/src/components/__tests__/Experience.test.tsx
+++ b/src/components/__tests__/Experience.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, within } from "@testing-library/react";
+
+import Experience from "../Experience";
+import { experiences } from "@avalon/configs/galahad";
+
+describe("Experience", () => {
+  it("renders the section heading and introduction", () => {
+    render(<Experience />);
+
+    expect(
+      screen.getByRole("heading", {
+        name: "Professional Experience",
+        level: 2,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "My professional journey and the impact I've made at different organizations.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("displays every experience card with duties and technologies", () => {
+    render(<Experience />);
+
+    const headings = screen.getAllByRole("heading", { level: 4 });
+    expect(headings).toHaveLength(experiences.length);
+
+    experiences.forEach((exp) => {
+      const titleHeading = screen.getByRole("heading", { name: exp.title });
+      const card = titleHeading.closest('[data-slot="card"]');
+      expect(card).not.toBeNull();
+      if (!card) {
+        throw new Error("Experience card not found for title: " + exp.title);
+      }
+      const utils = within(card);
+
+      expect(utils.getByText(exp.company)).toBeInTheDocument();
+      expect(utils.getByText(exp.location)).toBeInTheDocument();
+      expect(utils.getByText(exp.period)).toBeInTheDocument();
+      expect(utils.getByText(exp.type)).toBeInTheDocument();
+
+      exp.duties.forEach((duty) => {
+        expect(utils.getByText(duty)).toBeInTheDocument();
+      });
+
+      exp.technologies.forEach((tech) => {
+        const badge = utils.getByText(tech);
+        expect(badge).toBeInTheDocument();
+        expect(badge).toHaveAttribute("data-slot", "badge");
+      });
+    });
+  });
+});

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+
+import Footer from "../Footer";
+import { links, profile } from "@avalon/configs/galahad";
+import { scrollToSection } from "@avalon/components/ui/dom";
+
+vi.mock("@avalon/components/ui/dom", () => ({
+  scrollToSection: vi.fn(),
+}));
+
+const NAVIGATION_ITEMS = [
+  { label: "Home", href: "#Home" },
+  { label: "About", href: "#About" },
+  { label: "Experience", href: "#Experience" },
+  { label: "Projects", href: "#Projects" },
+  { label: "Certificates", href: "#Certificates" },
+];
+
+const QUICK_LINKS = [
+  { name: "AWS Console", link: "https://aws.amazon.com/" },
+  { name: "GCP Console", link: "https://console.cloud.google.com/" },
+  { name: "Azure Portal", link: "https://portal.azure.com/" },
+  { name: "Oracle Cloud", link: "https://cloud.oracle.com/login" },
+];
+
+describe("Footer", () => {
+  const scrollToSectionMock = vi.mocked(scrollToSection);
+
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-01T00:00:00Z"));
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders profile information and social links", () => {
+    render(<Footer />);
+
+    expect(
+      screen.getByRole("heading", {
+        name: `${profile.first_name} ${profile.last_name}`,
+        level: 3,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(profile.introduction)).toBeInTheDocument();
+
+    links.forEach((link) => {
+      const socialLink = screen.getByTitle(link.name);
+      expect(socialLink).toHaveAttribute("href", link.url);
+      expect(socialLink).toHaveAttribute("target", "_blank");
+      expect(socialLink).toHaveAttribute("rel", "noopener noreferrer");
+    });
+  });
+
+  it("renders quick links and navigation content", () => {
+    render(<Footer />);
+
+    QUICK_LINKS.forEach((quickLink) => {
+      const linkElement = screen.getByRole("link", { name: quickLink.name });
+      expect(linkElement).toHaveAttribute("href", quickLink.link);
+      expect(linkElement).toHaveAttribute("target", "_blank");
+      expect(linkElement).toHaveAttribute("rel", "noopener noreferrer");
+    });
+
+    NAVIGATION_ITEMS.forEach((item) => {
+      expect(
+        screen.getByRole("button", { name: `Go to ${item.label} section` }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("invokes scrollToSection with the correct section hash", async () => {
+    const user = userEvent.setup();
+    render(<Footer />);
+
+    for (const item of NAVIGATION_ITEMS) {
+      const button = screen.getByRole("button", {
+        name: `Go to ${item.label} section`,
+      });
+      await user.click(button);
+      expect(scrollToSectionMock).toHaveBeenLastCalledWith(item.href);
+    }
+
+    expect(scrollToSectionMock).toHaveBeenCalledTimes(NAVIGATION_ITEMS.length);
+  });
+
+  it("shows the current year and last updated text", () => {
+    render(<Footer />);
+
+    expect(
+      screen.getByText(
+        (content) =>
+          content.startsWith("© 2025 Galahad Zhao.") &&
+          content.includes("React & Tailwind CSS."),
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText("Last updated: October 2025"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -28,15 +28,6 @@ const QUICK_LINKS = [
 describe("Footer", () => {
   const scrollToSectionMock = vi.mocked(scrollToSection);
 
-  beforeAll(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2025-01-01T00:00:00Z"));
-  });
-
-  afterAll(() => {
-    vi.useRealTimers();
-  });
-
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -95,10 +86,12 @@ describe("Footer", () => {
   it("shows the current year and last updated text", () => {
     render(<Footer />);
 
+    const currentYear = new Date().getFullYear();
+
     expect(
       screen.getByText(
         (content) =>
-          content.startsWith("© 2025 Galahad Zhao.") &&
+          content.startsWith(`© ${currentYear} Galahad Zhao.`) &&
           content.includes("React & Tailwind CSS."),
       ),
     ).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- add coverage for the footer component including quick links, navigation buttons, and copyright text
- verify the experience section renders every configured card with duties and technology badges

## Testing
- yarn install *(fails: npm registry returned 403 so dependencies could not be installed)*
- yarn test src/components/__tests__/Footer.test.tsx src/components/__tests__/Experience.test.tsx *(not run: dependencies unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_69049252e5a8832cb0b654935573b214