### PR TITLE
Add atmospheric background image to hero section

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -3,6 +3,7 @@ import { cva } from "class-variance-authority";
 
 import { profile, links } from "@avalon/configs/galahad";
 import { cn } from "@avalon/components/ui/utils";
+import heroBackground from "@avalon/assets/hero-background.jpg";
 
 const HERO_PROFILE_STYLE = cva("", {
   variants: {
@@ -33,8 +34,11 @@ const HeroProfile = () => {
 const HERO_STYLE = cva("", {
   variants: {
     variant: {
-      section: "min-h-screen flex items-center justify-center px-4 pt-16",
-      topContainer: "container mx-auto",
+      section:
+        "relative min-h-screen flex items-center justify-center px-4 pt-16 overflow-hidden bg-cover bg-center",
+      overlay:
+        "pointer-events-none absolute inset-0 bg-gradient-to-br from-background/90 via-background/70 to-background/90 dark:from-background/80 dark:via-background/60 dark:to-background/80",
+      topContainer: "container mx-auto relative z-10",
       contentHolder: "max-w-4xl mx-auto text-center",
       name: "text-4xl md:text-6xl mb-4 bg-gradient-to-r from-foreground to-muted-foreground bg-clip-text text-transparent",
       title: "text-xl md:text-2xl text-muted-foreground mb-6",
@@ -46,7 +50,12 @@ const HERO_STYLE = cva("", {
 
 const Hero = () => {
   return (
-    <section id="Home" className={cn(HERO_STYLE({ variant: "section" }))}>
+    <section
+      id="Home"
+      className={cn(HERO_STYLE({ variant: "section" }))}
+      style={{ backgroundImage: `url(${heroBackground})` }}
+    >
+      <div className={cn(HERO_STYLE({ variant: "overlay" }))} aria-hidden />
       <div className={cn(HERO_STYLE({ variant: "topContainer" }))}>
         <div className={cn(HERO_STYLE({ variant: "contentHolder" }))}>
           <HeroProfile />

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -3,7 +3,7 @@ import { cva } from "class-variance-authority";
 
 import { profile, links } from "@avalon/configs/galahad";
 import { cn } from "@avalon/components/ui/utils";
-import heroBackground from "@avalon/assets/hero-background.jpg";
+import heroBackground from "@avalon/assets/hero-background-2.jpg";
 
 const HERO_PROFILE_STYLE = cva("", {
   variants: {
@@ -72,7 +72,7 @@ const Hero = () => {
             {profile.introduction}
           </p>
 
-          <Card className="p-6 max-w-md mx-auto dark:bg-muted/20">
+          <Card className="p-6 max-w-md mx-auto bg-muted/30 dark:bg-muted/20">
             <h3 className="mb-4 text-center">Connect with me</h3>
             <div className="flex justify-center space-x-6">
               {links.map((link) => {

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -3,7 +3,7 @@ import { cva } from "class-variance-authority";
 
 import { profile, links } from "@avalon/configs/galahad";
 import { cn } from "@avalon/components/ui/utils";
-import heroBackground from "@avalon/assets/hero-background-2.jpg";
+import heroSectionBackground from "@avalon/assets/hero-background.jpg";
 
 const HERO_PROFILE_STYLE = cva("", {
   variants: {
@@ -53,7 +53,7 @@ const Hero = () => {
     <section
       id="Home"
       className={cn(HERO_STYLE({ variant: "section" }))}
-      style={{ backgroundImage: `url(${heroBackground})` }}
+      style={{ backgroundImage: `url(${heroSectionBackground})` }}
     >
       <div className={cn(HERO_STYLE({ variant: "overlay" }))} aria-hidden />
       <div className={cn(HERO_STYLE({ variant: "topContainer" }))}>


### PR DESCRIPTION
## Summary
- use the provided hero background photo as the hero section backdrop
- add a tinted gradient overlay so content remains legible over the image

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913580c63a0832c91ff41b3eb4b6d03)