### PR TITLE
Add Portfolio component tests

### DIFF
--- a/src/components/__tests__/Portfolio.test.tsx
+++ b/src/components/__tests__/Portfolio.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 
 import Portfolio from "../Portfolio";
 import { holdings } from "@avalon/configs/galahad";
@@ -39,8 +39,15 @@ describe("Portfolio", () => {
       expect(assetLink).toHaveAttribute("href", asset.link);
       expect(assetLink).toHaveAttribute("target", "_blank");
       expect(assetLink).toHaveAttribute("rel", "noopener noreferrer");
+
+      const assetRow = assetLink.closest("div")?.parentElement;
+      if (!assetRow) {
+        throw new Error(`Asset legend row not found for ${asset.code}`);
+      }
+
+      const assetRowUtils = within(assetRow);
       expect(
-        screen.getByText(`${asset.percentage}%`),
+        assetRowUtils.getByText(`${asset.percentage}%`),
       ).toBeInTheDocument();
       expect(
         screen.getByTitle(`${asset.code}: ${asset.percentage}%`),
@@ -52,9 +59,15 @@ describe("Portfolio", () => {
     render(<Portfolio />);
 
     holdings.sectorAllocation.forEach((sector) => {
-      expect(screen.getByText(sector.name)).toBeInTheDocument();
+      const sectorName = screen.getByText(sector.name);
+      const sectorRow = sectorName.closest("div")?.parentElement;
+      if (!sectorRow) {
+        throw new Error(`Sector legend row not found for ${sector.name}`);
+      }
+
+      const sectorRowUtils = within(sectorRow);
       expect(
-        screen.getByText(`${sector.percentage}%`),
+        sectorRowUtils.getByText(`${sector.percentage}%`),
       ).toBeInTheDocument();
       expect(
         screen.getByTitle(`${sector.name}: ${sector.percentage}%`),

--- a/src/components/__tests__/Portfolio.test.tsx
+++ b/src/components/__tests__/Portfolio.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+
+import Portfolio from "../Portfolio";
+import { holdings } from "@avalon/configs/galahad";
+
+describe("Portfolio", () => {
+  it("renders the section header and metadata", () => {
+    render(<Portfolio />);
+
+    expect(
+      screen.getByRole("heading", { name: "Investment Portfolio", level: 2 }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "A quick look at my current investment holdings and sector allocation.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(`Last updated: ${holdings.lastUpdate}`),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the disclaimer copy", () => {
+    render(<Portfolio />);
+
+    expect(screen.getByText("Disclaimer:")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This information is shared for personal interests and educational purposes only. It is not financial advice, investment recommendation, or an endorsement of any securities.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("shows asset allocation legend entries with links and percentages", () => {
+    render(<Portfolio />);
+
+    holdings.assetAllocation.forEach((asset) => {
+      const assetLink = screen.getByRole("link", { name: asset.code });
+      expect(assetLink).toHaveAttribute("href", asset.link);
+      expect(assetLink).toHaveAttribute("target", "_blank");
+      expect(assetLink).toHaveAttribute("rel", "noopener noreferrer");
+      expect(
+        screen.getByText(`${asset.percentage}%`),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTitle(`${asset.code}: ${asset.percentage}%`),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows sector allocation legend entries with percentages", () => {
+    render(<Portfolio />);
+
+    holdings.sectorAllocation.forEach((sector) => {
+      expect(screen.getByText(sector.name)).toBeInTheDocument();
+      expect(
+        screen.getByText(`${sector.percentage}%`),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTitle(`${sector.name}: ${sector.percentage}%`),
+      ).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Ensure the `Portfolio` component renders the section header, metadata, and last updated timestamp correctly.
- Verify the disclaimer copy is present and matches the expected text.
- Validate asset and sector allocation legend entries render correct percentages and titles and that asset links have proper attributes.

### Description
- Add new test file `src/components/__tests__/Portfolio.test.tsx` with unit tests for the `Portfolio` component.
- Tests import `holdings` from `@avalon/configs/galahad` and assert header, metadata, and disclaimer content.
- Asset allocation tests assert link `href`, `target`, and `rel` attributes and check percentage and title rendering for each asset.
- Sector allocation tests assert sector names, percentages, and allocation title rendering.

### Testing
- No automated tests were executed as part of this change.
- The new unit test file was added and committed but not run locally or in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695798876204832cbb34350217111cbc)