### PR TITLE
Use composite keys for mapped lists in main components

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -91,7 +91,7 @@ const AboutSkillset = () => {
       <Card>
         <CardContent className="p-8 space-y-6">
           {skillsets.map((category, index) => (
-            <div key={index} className="space-y-3">
+            <div key={`${index}-${category.category}`} className="space-y-3">
               <h4 className="font-medium text-foreground">
                 {category.category}
               </h4>

--- a/src/components/Certificate.tsx
+++ b/src/components/Certificate.tsx
@@ -30,7 +30,7 @@ const CertificateGrid = ({ isDark }: { isDark: boolean }) => {
     <div className={cn(CERT_GRID_STYLE({ variant: "gridContainer" }))}>
       {certificates.map((cert, index) => (
         <Card
-          key={index}
+          key={`${index}-${cert.name}`}
           className={cn(CERT_GRID_STYLE({ variant: "cardHover" }))}
         >
           <CardHeader className="text-center">

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -32,7 +32,7 @@ const ExperienceContent = () => {
     <div className="space-y-8">
       {experiences.map((exp, index) => (
         <Card
-          key={index}
+          key={`${index}-${exp.company}`}
           className={cn(EXPERIENCE_CONTENT_STYLE({ variant: "cardHover" }))}
         >
           <CardHeader>
@@ -83,7 +83,7 @@ const ExperienceContent = () => {
             <ul className="space-y-2 mb-6">
               {exp.duties.map((item, index) => (
                 <li
-                  key={index}
+                  key={`${index}-${item}`}
                   className={cn(
                     EXPERIENCE_CONTENT_STYLE({ variant: "dutyContainer" }),
                   )}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -60,7 +60,7 @@ const Header = ({
           <nav className={cn(HEADER_STYLE({ variant: "navigation" }))}>
             {NAV_ITEMS.map((item, index) => (
               <HeaderButton
-                key={index}
+                key={`${index}-${item}`}
                 buttonName={item}
                 onClick={() => {
                   scrollToSection(`#${item}`);

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -48,7 +48,7 @@ const PortfolioContent = () => {
             >
               {holdings.assetAllocation.map((asset, index) => (
                 <div
-                  key={index}
+                  key={`${index}-${asset.code}`}
                   className={cn(
                     PORTFOLIO_CONTENT_STYLE({ variant: "allocationItem" }),
                     asset.color,
@@ -69,7 +69,10 @@ const PortfolioContent = () => {
           {/* Legend */}
           <div className="space-y-3">
             {holdings.assetAllocation.map((asset, index) => (
-              <div key={index} className="flex items-center justify-between">
+              <div
+                key={`${index}-${asset.code}`}
+                className="flex items-center justify-between"
+              >
                 <div className="flex items-center gap-3">
                   <div className={`${asset.color} `} />
                   <a
@@ -109,7 +112,7 @@ const PortfolioContent = () => {
             <div className="w-full h-8 bg-muted rounded-lg overflow-hidden flex">
               {holdings.sectorAllocation.map((sector, index) => (
                 <div
-                  key={index}
+                  key={`${index}-${sector.name}`}
                   className={cn(
                     PORTFOLIO_CONTENT_STYLE({ variant: "allocationItem" }),
                     sector.color,
@@ -130,7 +133,10 @@ const PortfolioContent = () => {
           {/* Legend */}
           <div className="space-y-3">
             {holdings.sectorAllocation.map((sector, index) => (
-              <div key={index} className="flex items-center justify-between">
+              <div
+                key={`${index}-${sector.name}`}
+                className="flex items-center justify-between"
+              >
                 <div className="flex items-center gap-3">
                   <div
                     className={cn(

--- a/src/components/Project.tsx
+++ b/src/components/Project.tsx
@@ -35,7 +35,7 @@ const ProjectContent = () => {
       <div className={cn(PROJECT_CONTENT_STYLE({ variant: "gridContainer" }))}>
         {projects.map((project, index) => (
           <Card
-            key={index}
+            key={`${index}-${project.name}`}
             className={cn(PROJECT_CONTENT_STYLE({ variant: "cardHover" }))}
           >
             <CardHeader>


### PR DESCRIPTION
### Motivation
- Replace unstable index-only React keys to reduce re-render issues when lists change order or content.
- Make keys more descriptive and unique by combining index with a stable identifier from the item.
- Apply consistent key strategy across primary components that render arrays for reliability.
- Follow React best-practices to prevent potential UI bugs and improve reconciliation.

### Description
- Updated header navigation to use `key={`${index}-${item}`}` for `HeaderButton` in `src/components/Header.tsx`.
- Replaced index-only keys with composite keys in `src/components/Portfolio.tsx` for `assetAllocation` and `sectorAllocation` items using `${index}-${asset.code}` and `${index}-${sector.name}` respectively, including their legend entries.
- Changed skill category, experience, project, and certificate list keys to composite forms: `src/components/About.tsx` uses `key={`${index}-${category.category}`}`, `src/components/Experience.tsx` uses `key={`${index}-${exp.company}`}` and duty items use `key={`${index}-${item}`}`, `src/components/Project.tsx` uses `key={`${index}-${project.name}`}`, and `src/components/Certificate.tsx` uses `key={`${index}-${cert.name}`}`.
- Minor cleanup to ensure all mapped elements in the modified components use stable composite keys instead of bare indices.

### Testing
- No automated tests were executed as part of this change.
- No unit or integration test runs were requested or performed.
- Manual inspection of modified files was done via repository searches to ensure all targeted `index`-only keys were updated.
- Type checking or build validation was not run automatically.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957d05080dc832ca4eab19e9cb9694b)