### PR TITLE
Fix tests for NavButton data-slot rename

### DIFF
--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -44,7 +44,7 @@ describe("Header", () => {
 
     const themeButton = screen
       .getAllByRole("button")
-      .find((button) => button.dataset.slot === "theme-button");
+      .find((button) => button.dataset.slot === "nav-button");
     expect(themeButton).toBeDefined();
     if (!themeButton) {
       throw new Error("Theme button not found");

--- a/src/components/ui/__tests__/buttons.test.tsx
+++ b/src/components/ui/__tests__/buttons.test.tsx
@@ -64,7 +64,7 @@ describe("NavButton", () => {
     );
 
     const button = screen.getByRole("button", { name: "Toggle theme" });
-    expect(button).toHaveAttribute("data-slot", "theme-button");
+    expect(button).toHaveAttribute("data-slot", "nav-button");
     expect(button).toHaveClass("hover:bg-accent", "size-9", "theme-custom");
 
     fireEvent.click(button);
@@ -81,7 +81,7 @@ describe("NavButton", () => {
 
     const link = screen.getByLabelText("Theme link");
     expect(link.tagName).toBe("A");
-    expect(link).toHaveAttribute("data-slot", "theme-button");
+    expect(link).toHaveAttribute("data-slot", "nav-button");
     expect(link).toHaveClass("hover:bg-accent", "size-9", "link-theme");
 
     fireEvent.click(link);


### PR DESCRIPTION
### Motivation
- The `NavButton` component was updated to use `data-slot="nav-button"` and tests still expected the old `theme-button` value.
- Header test logic attempted to locate the theme button using the previous `data-slot` value which no longer matched the rendered DOM.

### Description
- Update expectations in `src/components/ui/__tests__/buttons.test.tsx` to check for `data-slot="nav-button"` on both the button and asChild link.
- Adjust `src/components/__tests__/Header.test.tsx` to locate the theme button by `dataset.slot === "nav-button"` when asserting icon swap behavior.
- Only test files were modified to align with the component rename.

### Testing
- Ran `yarn vitest run src/components/ui/__tests__/buttons.test.tsx src/components/__tests__/Header.test.tsx`.
- All tests in the two modified files passed (8 tests total, all green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957d64dcb1c832ca8605c0cee797f08)